### PR TITLE
Consider url suffixed by / as a directory

### DIFF
--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path"
 	"log"
+	"strings"
 )
 
 type Server struct {
@@ -43,7 +44,7 @@ func (s Server) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Println("Handling request for: ", objPath)
 
-	if objPath != "/" {
+	if objPath != "/" && !strings.HasSuffix(objPath,"/") {
 		isFile, err := s.repository.IsFile(objPath)
 		if err != nil {
 			handleError(err, w)


### PR DESCRIPTION
Hello,

When the GET url is ending by / in a directory, it was considered as a file instead of a directory. We wanted the same result if we call http://host/mydirectory and http://host/mydirectory/

I am not sure it's a good fix, but it's working for us, I then propose and let you decide if it can be useful or not !

Thanks for init this project ;).